### PR TITLE
Added type to the int parameters. They were wrongly interpreted as st…

### DIFF
--- a/train.py
+++ b/train.py
@@ -150,11 +150,11 @@ def main():
     parser.add_argument('-epoch', type=int, default=10)
     parser.add_argument('-batch_size', type=int, default=64)
 
-    parser.add_argument('-d_word_vec', default=512)
-    parser.add_argument('-d_model', default=512)
-    parser.add_argument('-d_inner_hid', default=1024)
-    parser.add_argument('-d_k', default=64)
-    parser.add_argument('-d_v', default=64)
+    parser.add_argument('-d_word_vec', type=int, default=512)
+    parser.add_argument('-d_model', type=int, default=512)
+    parser.add_argument('-d_inner_hid', type=int, default=1024)
+    parser.add_argument('-d_k', type=int, default=64)
+    parser.add_argument('-d_v', type=int, default=64)
 
     parser.add_argument('-n_head', type=int, default=8)
     parser.add_argument('-n_layers', type=int, default=4)


### PR DESCRIPTION
…rings

When I tried to run a training before the edit I was getting this error:

```bash
Traceback (most recent call last):
  File "attention-is-all-you-need-pytorch/train.py", line 244, in <module>
    main()
  File "attention-is-all-you-need-pytorch/train.py", line 221, in main
    dropout=opt.dropout)
  File "/hardmnt/hltmt0/data/digangi/attention-is-all-you-need-pytorch/transformer/Models.py", line 146, in __init__
    d_inner_hid=d_inner_hid, dropout=dropout)
  File "/hardmnt/hltmt0/data/digangi/attention-is-all-you-need-pytorch/transformer/Models.py", line 55, in __init__
    self.position_enc = nn.Embedding(n_position, d_word_vec, padding_idx=Constants.PAD)
  File "/hltmt0/data/digangi/anaconda3/lib/python3.6/site-packages/torch/nn/modules/sparse.py", line 77, in __init__
    self.weight = Parameter(torch.Tensor(num_embeddings, embedding_dim))
TypeError: torch.FloatTensor constructor received an invalid combination of arguments - got (int, str), but expected one of:
 * no arguments
 * (int ...)
      didn't match because some of the arguments have invalid types: (int, str)
 * (torch.FloatTensor viewed_tensor)
 * (torch.Size size)
 * (torch.FloatStorage data)
 * (Sequence data)
```