### PR TITLE
Correct LayerNormalization

### DIFF
--- a/transformer/Modules.py
+++ b/transformer/Modules.py
@@ -47,8 +47,8 @@ class LayerNormalization(nn.Module):
         if z.size(1) == 1:
             return z
 
-        mu = torch.mean(z, dim=1)
-        sigma = torch.std(z, dim=1)
+        mu = torch.mean(z, dim=-1)
+        sigma = torch.std(z, dim=-1)
         ln_out = (z - mu.expand_as(z)) / (sigma.expand_as(z) + self.eps)
         ln_out = ln_out * self.a_2.expand_as(ln_out) + self.b_2.expand_as(ln_out)
 


### PR DESCRIPTION
I really appreciate your code but I'm pretty sure that your `LayerNormalization` class is wrong. In the `50-51` lines of `transformer/Modules.py`, the size of `z` is `(batch_size, seq_len, feature_dim)`. Your original implementation computes the mean and standard-deviation along the dimsion `seq_len`. But the Layer Normalization should compute these values along the dimsion `feature_dim`, as you can see in the [paper](https://arxiv.org/pdf/1607.06450.pdf).

More specifically, you can see the formulas below. 
![ln](https://user-images.githubusercontent.com/12484804/28236617-b1460ed6-68ef-11e7-935f-662a751fa069.png)

