### PR TITLE
Fix an error on Windows about 32, 64-bit integer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+.idea/

--- a/transformer/Beam.py
+++ b/transformer/Beam.py
@@ -87,7 +87,7 @@ class Beam(object):
             _, keys = self.sort_scores()
             hyps = [self.get_hypothesis(k) for k in keys]
             hyps = [[Constants.BOS] + h for h in hyps]
-            dec_seq = torch.from_numpy(np.array(hyps))
+            dec_seq = torch.from_numpy(np.array(hyps, dtype=np.int64))
 
         return dec_seq
 


### PR DESCRIPTION
I run `translate.py` on my Windows machine (with Windows 10 64-bit, Anaconda and PyTorch from [this Anaconda package](https://anaconda.org/peterjc123/pytorch)) and run into the following error:

> Traceback (most recent call last):
  File "C:/Users/yao_z/Documents/attention-is-all-you-need-pytorch/translate.py", line 66, in <module>
    main()
  File "C:/Users/yao_z/Documents/attention-is-all-you-need-pytorch/translate.py", line 58, in main
    all_hyp, all_scores = translator.translate_batch(batch)
  File "C:\Users\yao_z\Documents\attention-is-all-you-need-pytorch\transformer\Translator.py", line 107, in translate_batch
    dec_partial_seq, dec_partial_pos, src_seq, enc_output)
  File "C:\Users\yao_z\Miniconda3\envs\pytorch\lib\site-packages\torch\nn\modules\module.py", line 357, in __call__
    result = self.forward(*input, **kwargs)
  File "C:\Users\yao_z\Documents\attention-is-all-you-need-pytorch\transformer\Models.py", line 111, in forward
    dec_input = self.tgt_word_emb(tgt_seq)
  File "C:\Users\yao_z\Miniconda3\envs\pytorch\lib\site-packages\torch\nn\modules\module.py", line 357, in __call__
    result = self.forward(*input, **kwargs)
  File "C:\Users\yao_z\Miniconda3\envs\pytorch\lib\site-packages\torch\nn\modules\sparse.py", line 103, in forward
    self.scale_grad_by_freq, self.sparse
  File "C:\Users\yao_z\Miniconda3\envs\pytorch\lib\site-packages\torch\nn\_functions\thnn\sparse.py", line 59, in forward
    output = torch.index_select(weight, 0, indices.view(-1))
TypeError: torch.index_select received an invalid combination of arguments - got (torch.cuda.FloatTensor, int, !torch.cuda.IntTensor!), but expected (torch.cuda.FloatTensor source, int dim, torch.cuda.LongTensor index)

This is because in the following code snippet from [Beam.py](https://github.com/jadore801120/attention-is-all-you-need-pytorch/blob/master/transformer/Beam.py), dec_seq is returned as a numpy `ndarray` with `dtype=np.int32`, not `np.int64`.  
```
def get_tentative_hypothesis(self):
        "Get the decoded sequence for the current timestep."

        if len(self.next_ys) == 1:
            dec_seq = self.next_ys[0].unsqueeze(1)
        else:
            _, keys = self.sort_scores()
            hyps = [self.get_hypothesis(k) for k in keys]
            hyps = [[Constants.BOS] + h for h in hyps]
            dec_seq = torch.from_numpy(np.array(hyps))

        return dec_seq
```

On Windows, even 64 bit Windows and 64 bit Anaconda, numpy uses 32-bit integer as the default integral type, as is illustrated in the following picture and you can see more from [here](https://stackoverflow.com/questions/36278590/numpy-array-dtype-is-coming-as-int32-by-default-in-a-windows-10-64-bit-machine):

![capture](https://user-images.githubusercontent.com/17451991/39031832-3b57d77e-449d-11e8-93d3-d965eb8b074a.PNG)

As a result, in the following code snippet from [Translator.py](https://github.com/jadore801120/attention-is-all-you-need-pytorch/blob/master/transformer/Translator.py), `dec_partial_seq` is an `IntTensor` instead of a `LongTensor`, which leads to the error I mentioned previously. 
```
 # -- Decoding -- #
            dec_output, *_ = self.model.decoder(
dec_partial_seq, dec_partial_pos, src_seq, enc_output)
```

Therefore, I add `dtype=np.int64` argument, the error disappears and it now runs smoothly on Windows.
