### PR TITLE
fix missing dropout on the embeddings

### DIFF
--- a/transformer/Models.py
+++ b/transformer/Models.py
@@ -64,6 +64,8 @@ class Encoder(nn.Module):
 
         n_position = len_max_seq + 1
 
+        self.dropout_emb = nn.Dropout(dropout)
+        
         self.src_word_emb = nn.Embedding(
             n_src_vocab, d_word_vec, padding_idx=Constants.PAD)
 
@@ -85,7 +87,8 @@ class Encoder(nn.Module):
 
         # -- Forward
         enc_output = self.src_word_emb(src_seq) + self.position_enc(src_pos)
-
+        enc_output = self.dropout_emb(enc_output)
+        
         for enc_layer in self.layer_stack:
             enc_output, enc_slf_attn = enc_layer(
                 enc_output,


### PR DESCRIPTION
There should be dropout on the embeddings, before feeding them to the encoder layers. See the reference implementation:
https://github.com/tensorflow/models/blob/master/official/transformer/model/transformer.py#L124
and see its absence here:
https://github.com/jadore801120/attention-is-all-you-need-pytorch/blob/master/transformer/Models.py#L87

see https://github.com/jadore801120/attention-is-all-you-need-pytorch/issues/69