### PR TITLE
Fix LayerNorm.

### DIFF
--- a/transformer/SubLayers.py
+++ b/transformer/SubLayers.py
@@ -33,7 +33,6 @@ class MultiHeadAttention(nn.Module):
         sz_b, len_q, len_k, len_v = q.size(0), q.size(1), k.size(1), v.size(1)
 
         residual = q
-        q = self.layer_norm(q)
 
         # Pass through the pre-attention projection: b x lq x (n*dv)
         # Separate different heads: b x lq x n x dv
@@ -43,7 +42,7 @@ class MultiHeadAttention(nn.Module):
 
         # Transpose for attention dot product: b x n x lq x dv
         q, k, v = q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
-        
+
         if mask is not None:
             mask = mask.unsqueeze(1)   # For head axis broadcasting.
 
@@ -54,6 +53,8 @@ class MultiHeadAttention(nn.Module):
         q = q.transpose(1, 2).contiguous().view(sz_b, len_q, -1)
         q = self.dropout(self.fc(q))
         q += residual
+
+        q = self.layer_norm(q)
 
         return q, attn
 


### PR DESCRIPTION
According to "attention is all you need", the formula
apply to sublayer is supposed to be LayerNorm(x + Sublayer(x)).

As mentioned in
[issue#142](https://github.com/jadore801120/attention-is-all-you-need-pytorch/issues/142),
this implementation results from the consideration of the problem in pytorch(see [pytorch
issue#4320](https://github.com/pytorch/pytorch/issues/4320)), which has
been fix in [Fix standard deviation gradient](https://github.com/pytorch/pytorch/pull/9238).

related experience statistics
```
python train.py -data_pkl m30k_deen_shr.pkl -log m30k_deen_shr -embs_share_weight -proj_share_weight -label_smoothing -save_model trained -b 128 -warmup 12800 -epoch 40

Epoch 39
* original version
- (Training)   ppl:  355.27087, accuracy: 13.232 %, elapse: 0.691 min
- (Validation) ppl:  284.94428, accuracy: 11.988 %, elapse: 0.007 min

* follow formula in the paper
- (Training)   ppl:  297.18417, accuracy: 15.274 %, elapse: 0.696 min
- (Validation) ppl:  1478.94354, accuracy: 11.988 %, elapse: 0.007 min
```
co-contributor: @yichung279