### PR TITLE
Fix Two Potential Bugs, with Significant Accuracy Improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ If there is any suggestion or error, feel free to fire an issue to let me know. 
 - tqdm
 - dill
 - numpy
+- tensorboard
 
 
 # Usage
@@ -54,7 +55,7 @@ python preprocess.py -lang_src de -lang_trg en -share_vocab -save_data m30k_deen
 
 ### 2) Train the model
 ```bash
-python train.py -data_pkl m30k_deen_shr.pkl -log m30k_deen_shr -embs_share_weight -proj_share_weight -label_smoothing -save_model trained -b 256 -warmup 128000 -epoch 400
+python train.py -data_pkl m30k_deen_shr.pkl -log m30k_deen_shr -embs_share_weight -proj_share_weight -label_smoothing -output_dir output -b 256 -warmup 128000 -epoch 400
 ```
 
 ### 3) Test the model
@@ -73,7 +74,7 @@ python preprocess.py -raw_dir /tmp/raw_deen -data_dir ./bpe_deen -save_data bpe_
 
 ### 2) Train the model
 ```bash
-python train.py -data_pkl ./bpe_deen/bpe_vocab.pkl -train_path ./bpe_deen/deen-train -val_path ./bpe_deen/deen-val -log deen_bpe -embs_share_weight -proj_share_weight -label_smoothing -save_model trained -b 256 -warmup 128000 -epoch 400
+python train.py -data_pkl ./bpe_deen/bpe_vocab.pkl -train_path ./bpe_deen/deen-train -val_path ./bpe_deen/deen-val -log deen_bpe -embs_share_weight -proj_share_weight -label_smoothing -output_dir output -b 256 -warmup 128000 -epoch 400
 ```
 
 ### 3) Test the model (not ready)

--- a/train_multi30k_de_en.sh
+++ b/train_multi30k_de_en.sh
@@ -1,0 +1,16 @@
+# Example:
+# gpu=0 lr_mul=2 scale_emb_or_prj=prj bash train_multi30k_de_en.sh
+# The better setting is:
+# gpu=0 lr_mul=0.5 scale_emb_or_prj=emb bash train_multi30k_de_en.sh
+CUDA_VISIBLE_DEVICES=${gpu} python train.py \
+-data_pkl multi30k_de_en.pkl \
+-label_smoothing \
+-proj_share_weight \
+-scale_emb_or_prj ${scale_emb_or_prj} \
+-lr_mul ${lr_mul} \
+-b 256 \
+-warmup 4000 \
+-epoch 200 \
+-seed 1 \
+-output_dir output/lr_mul_${lr_mul}-scale_${scale_emb_or_prj} \
+-use_tb

--- a/transformer/Models.py
+++ b/transformer/Models.py
@@ -50,7 +50,7 @@ class Encoder(nn.Module):
 
     def __init__(
             self, n_src_vocab, d_word_vec, n_layers, n_head, d_k, d_v,
-            d_model, d_inner, pad_idx, dropout=0.1, n_position=200):
+            d_model, d_inner, pad_idx, dropout=0.1, n_position=200, scale_emb=False):
 
         super().__init__()
 
@@ -61,14 +61,18 @@ class Encoder(nn.Module):
             EncoderLayer(d_model, d_inner, n_head, d_k, d_v, dropout=dropout)
             for _ in range(n_layers)])
         self.layer_norm = nn.LayerNorm(d_model, eps=1e-6)
+        self.scale_emb = scale_emb
+        self.d_model = d_model
 
     def forward(self, src_seq, src_mask, return_attns=False):
 
         enc_slf_attn_list = []
 
         # -- Forward
-        
-        enc_output = self.dropout(self.position_enc(self.src_word_emb(src_seq)))
+        enc_output = self.src_word_emb(src_seq)
+        if self.scale_emb:
+            enc_output *= self.d_model ** 0.5
+        enc_output = self.dropout(self.position_enc(enc_output))
         enc_output = self.layer_norm(enc_output)
 
         for enc_layer in self.layer_stack:
@@ -85,7 +89,7 @@ class Decoder(nn.Module):
 
     def __init__(
             self, n_trg_vocab, d_word_vec, n_layers, n_head, d_k, d_v,
-            d_model, d_inner, pad_idx, n_position=200, dropout=0.1):
+            d_model, d_inner, pad_idx, n_position=200, dropout=0.1, scale_emb=False):
 
         super().__init__()
 
@@ -96,13 +100,18 @@ class Decoder(nn.Module):
             DecoderLayer(d_model, d_inner, n_head, d_k, d_v, dropout=dropout)
             for _ in range(n_layers)])
         self.layer_norm = nn.LayerNorm(d_model, eps=1e-6)
+        self.scale_emb = scale_emb
+        self.d_model = d_model
 
     def forward(self, trg_seq, trg_mask, enc_output, src_mask, return_attns=False):
 
         dec_slf_attn_list, dec_enc_attn_list = [], []
 
         # -- Forward
-        dec_output = self.dropout(self.position_enc(self.trg_word_emb(trg_seq)))
+        dec_output = self.trg_word_emb(trg_seq)
+        if self.scale_emb:
+            dec_output *= self.d_model ** 0.5
+        dec_output = self.dropout(self.position_enc(dec_output))
         dec_output = self.layer_norm(dec_output)
 
         for dec_layer in self.layer_stack:
@@ -123,23 +132,39 @@ class Transformer(nn.Module):
             self, n_src_vocab, n_trg_vocab, src_pad_idx, trg_pad_idx,
             d_word_vec=512, d_model=512, d_inner=2048,
             n_layers=6, n_head=8, d_k=64, d_v=64, dropout=0.1, n_position=200,
-            trg_emb_prj_weight_sharing=True, emb_src_trg_weight_sharing=True):
+            trg_emb_prj_weight_sharing=True, emb_src_trg_weight_sharing=True,
+            scale_emb_or_prj='prj'):
 
         super().__init__()
 
         self.src_pad_idx, self.trg_pad_idx = src_pad_idx, trg_pad_idx
 
+        # In section 3.4 of paper "Attention Is All You Need", there is such detail:
+        # "In our model, we share the same weight matrix between the two
+        # embedding layers and the pre-softmax linear transformation...
+        # In the embedding layers, we multiply those weights by \sqrt{d_model}".
+        #
+        # Options here:
+        #   'emb': multiply \sqrt{d_model} to embedding output
+        #   'prj': multiply (\sqrt{d_model} ^ -1) to linear projection output
+        #   'none': no multiplication
+
+        assert scale_emb_or_prj in ['emb', 'prj', 'none']
+        scale_emb = (scale_emb_or_prj == 'emb') if trg_emb_prj_weight_sharing else False
+        self.scale_prj = (scale_emb_or_prj == 'prj') if trg_emb_prj_weight_sharing else False
+        self.d_model = d_model
+
         self.encoder = Encoder(
             n_src_vocab=n_src_vocab, n_position=n_position,
             d_word_vec=d_word_vec, d_model=d_model, d_inner=d_inner,
             n_layers=n_layers, n_head=n_head, d_k=d_k, d_v=d_v,
-            pad_idx=src_pad_idx, dropout=dropout)
+            pad_idx=src_pad_idx, dropout=dropout, scale_emb=scale_emb)
 
         self.decoder = Decoder(
             n_trg_vocab=n_trg_vocab, n_position=n_position,
             d_word_vec=d_word_vec, d_model=d_model, d_inner=d_inner,
             n_layers=n_layers, n_head=n_head, d_k=d_k, d_v=d_v,
-            pad_idx=trg_pad_idx, dropout=dropout)
+            pad_idx=trg_pad_idx, dropout=dropout, scale_emb=scale_emb)
 
         self.trg_word_prj = nn.Linear(d_model, n_trg_vocab, bias=False)
 
@@ -151,11 +176,9 @@ class Transformer(nn.Module):
         'To facilitate the residual connections, \
          the dimensions of all module outputs shall be the same.'
 
-        self.x_logit_scale = 1.
         if trg_emb_prj_weight_sharing:
             # Share the weight between target word embedding & last dense layer
             self.trg_word_prj.weight = self.decoder.trg_word_emb.weight
-            self.x_logit_scale = (d_model ** -0.5)
 
         if emb_src_trg_weight_sharing:
             self.encoder.src_word_emb.weight = self.decoder.trg_word_emb.weight
@@ -168,6 +191,8 @@ class Transformer(nn.Module):
 
         enc_output, *_ = self.encoder(src_seq, src_mask)
         dec_output, *_ = self.decoder(trg_seq, trg_mask, enc_output, src_mask)
-        seq_logit = self.trg_word_prj(dec_output) * self.x_logit_scale
+        seq_logit = self.trg_word_prj(dec_output)
+        if self.scale_prj:
+            seq_logit *= self.d_model ** -0.5
 
         return seq_logit.view(-1, seq_logit.size(2))

--- a/transformer/Optim.py
+++ b/transformer/Optim.py
@@ -4,9 +4,9 @@ import numpy as np
 class ScheduledOptim():
     '''A simple wrapper class for learning rate scheduling'''
 
-    def __init__(self, optimizer, init_lr, d_model, n_warmup_steps):
+    def __init__(self, optimizer, lr_mul, d_model, n_warmup_steps):
         self._optimizer = optimizer
-        self.init_lr = init_lr
+        self.lr_mul = lr_mul
         self.d_model = d_model
         self.n_warmup_steps = n_warmup_steps
         self.n_steps = 0
@@ -33,7 +33,7 @@ class ScheduledOptim():
         ''' Learning rate scheduling per step '''
 
         self.n_steps += 1
-        lr = self.init_lr * self._get_lr_scale()
+        lr = self.lr_mul * self._get_lr_scale()
 
         for param_group in self._optimizer.param_groups:
             param_group['lr'] = lr


### PR DESCRIPTION
Hi, @jadore801120 , thank you a lot for sharing your transformer implementation.

I find two points that have negative impact on training stability and validation accuracy in your code. And I have made modifications that solve the problem in this pull request.

## Experimental Setting

My experiments are conducted on multi30k-de-en without BPE, with batch size 256, warmup steps 4000 (equivalent to 34 epochs), and total epochs 200 (equivalent to 23400 steps). Other parameters can be found in `train_multi30k_de_en.sh` provided in this commit.

I install Spacy German language model via `pip install de_core_news_sm-2.3.0.tar.gz`, and the English model `conda install -c conda-forge spacy-model-en_core_web_lg`. This is because I encounter connection error while running `python -m spacy download de` and `python -m spacy download en`.

## 1. Learning Rate Magnitude

The learning rate in paper [Attention Is All You Need](https://arxiv.org/abs/1706.03762) is as follows, which corresponds to your code [at this line](https://github.com/jadore801120/attention-is-all-you-need-pytorch/blob/fec78a687210851f055f792d45300d27cc60ae41/transformer/Optim.py#L29).

<p align="center">
  <img src="https://user-images.githubusercontent.com/13362456/104271859-cf256100-54d6-11eb-97a5-eed8909acb63.png" width="600" />
</p>

The learning rate curve can be controlled by two main parameters, warmup steps and multiplication factor.

The curves w.r.t. warmup steps are shown below:

<p align="center">
  <img src="https://user-images.githubusercontent.com/13362456/104275923-bfaa1600-54de-11eb-9c48-70d2d393a50b.png" width="500" />
</p>

We can see that, if we want to scale down the maximum learning rate by a half from 7e-4 to 3.5e-4, we have to increase warmup steps from 4000 to 16000. Now consider dataset multi30k-de-en, which has 30000 training samples. When batch size is 256, an epoch contains only 117 steps. Thus 16000 warmup steps is 136 epochs, which would take much longer time to train.

We see that **warmup steps is not a flexible parameter for setting up learning rate**. The better way to use a multiplication factor, as done [in this line of code](https://github.com/jadore801120/attention-is-all-you-need-pytorch/blob/fec78a687210851f055f792d45300d27cc60ae41/transformer/Optim.py#L36). I will call it `lr_mul` instead of `init_lr`, since it does not equal to initial learning rate, or highest point of learning rate.

I find that `lr_mul` is hard coded as `2.0` in [`train.py`](https://github.com/jadore801120/attention-is-all-you-need-pytorch/blob/fec78a687210851f055f792d45300d27cc60ae41/train.py#L271).

The learning rates, with different multiplication factors, are shown below:

<p align="center">
  <img src="https://user-images.githubusercontent.com/13362456/104277246-78715480-54e1-11eb-9eb3-866ec3d11cc6.png" width="500" />
</p>

In the above figure, we observe that, when `lr_mul = 2`, the highest learning rate is 1.4e-3, which is too large as verified in my following experiments. I also find `lr_mul = 1` too large, while `lr_mul = 0.5` is satisfactory. The accuracy and perplexity during training and validation are shown below:
![image](https://user-images.githubusercontent.com/13362456/104277756-60e69b80-54e2-11eb-9a58-c197555e6249.png)

From the above figure, we see that **too large a learning rate would drag down the accuracy curve after some period and make it unable to recover**. BTW, this phenomenon was also observed while I used a batch size 768 (with multiple GPUs).

For `lr_mul = 0.5`, the validation accuracy converges within 100 epochs (or 11700 steps). The final performance is
|train accuracy (%) | train ppl | valid accuracy (%) | valid ppl |
|:-:|:-:|:-:|:-:|
|98.253 | 3.94835 | 55.886 | 20.08619 |

I believe these experiments are helpful for solving these issues: #60, #94, #101, #141, #147.

## 2. Scaling Projection or Word Embedding

In paper [Attention Is All You Need](https://arxiv.org/abs/1706.03762), the authors share word embedding layer with output projection layer, but with a scaling factor `sqrt(d_model)` on the embedding.

<p align="center">
  <img src="https://user-images.githubusercontent.com/13362456/104279640-95a82200-54e5-11eb-8726-71d1d547a017.png" width="600" />
</p>

In this repository, however, you place the reciprocal scaling factor `1 / sqrt(d_model)` on the projection side, as [in this line of code](https://github.com/jadore801120/attention-is-all-you-need-pytorch/blob/fec78a687210851f055f792d45300d27cc60ae41/transformer/Models.py#L158). I find it has been discussed in this issue #138.

I am not sure if this implementation is equivalent to the paper's. However, **I find significant performance gain over the current code, if we implement it on the embedding side.**

I experiment with (1) scaling on the embedding side, (2) scaling on the projection side, (3) no scaling. The learning rate multiplication `lr_mul = 0.5`. The results are as follows:
![image](https://user-images.githubusercontent.com/13362456/104280662-3ea34c80-54e7-11eb-9efa-06ba072e8600.png)

The results show significant difference in convergence speed and validation accuracy. Scaling on the projection side is much slower in convergence, and its validation accuracy is 10.5% lower than on the embedding side (55.886% vs. 66.392%). Maybe scaling the vector before softmax function with `1 / sqrt(d_model) = 1 / sqrt(512) = 0.044` makes softmax difficult to train.

The final performances, with `lr_mul = 0.5` are shown below
| |train accuracy (%) | train ppl | valid accuracy (%) | valid ppl |
|:-:|:-:|:-:|:-:|:-:|
| scaling prj |98.253 | 3.94835 | 55.886 | 20.08619 |
| scaling emb | **99.735** | **3.36672** | **66.392** | 11.73074 |
| no scaling | **99.735** | 3.46923 | 65.478 | **10.35122** |

The slow convergence rate when scaling on the projection side may also provide some hints for this issue: #101.

## Overview of This Pull Request

1. This pull request has made the `lr_mul` parameter configurable.
2. This pull request has made the scaling setting (either on the word embedding side, or on the projection side, or none) configurable.
3. Add seed option for reproducibility of experiments.
4. Save experiment output to directory, making the project directory much cleaner.
5. Optional to use tensorboard to plot curves during training, including perplexity, accuracy, and learning rate, etc.

Once more, I would like to express my appreciation for your sharing the detailed implementation of transformer. I have learned a lot from this code. I hope the pull request would make it clearer for beginners like me to reproduce promising results.