### PR TITLE
removed a singleton-comparison pitfall

### DIFF
--- a/apply_bpe.py
+++ b/apply_bpe.py
@@ -237,7 +237,7 @@ def read_vocabulary(vocab_file, threshold):
     for line in vocab_file:
         word, freq = line.strip('\r\n ').split(' ')
         freq = int(freq)
-        if threshold == None or freq >= threshold:
+        if threshold is None or freq >= threshold:
             vocabulary.add(word)
 
     return vocabulary


### PR DESCRIPTION
**Problem:**
The code had a pitfall known as singleton-comparison.
In Python, when comparing singletons, like None, True or False, it's safer to use the 'is' operator instead of '=='.
Constructions like:
```python
foo == True
bar == False
foobar == None
```
Are preferred to be written as:

```python
foo is True
bar is False
foobar is None
```



These discussions give some highlight into this topic
https://stackoverflow.com/questions/1011431/common-pitfalls-in-python
https://stackoverflow.com/questions/2209755/python-operation-vs-is-not

**Solution:**
This pull request simply removes this pitfall from the code.
